### PR TITLE
Add error when loading ingame rather than on COS-PC

### DIFF
--- a/gFont.lua
+++ b/gFont.lua
@@ -1,3 +1,6 @@
+if not term.getGraphicsMode then
+    error("Cannot run in-game. Requires CraftOS-PC.", 0)
+end
 if term.getGraphicsMode() == 0 then
     printError("OS doesnt support graphics mode 1 or higher!")
 end


### PR DESCRIPTION
This PR causes the library to throw an error when it is loaded ingame, rather than on CraftOS-PC. The reasoning for this is that ingame computers do not have graphicsmode, and thus cannot run it anyways.